### PR TITLE
Added debounced digital read

### DIFF
--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -419,6 +419,42 @@ Board.prototype.digitalRead = function(pin, callback) {
 };
 
 /**
+ * Sets given pin to INPUT Mode and provides a debounced digitalRead callback
+ * @param {number} pin The pin to be debounced
+ * @param {function} callback Debounced Callback
+ * @param {number} sens Sensitivy in milliseconds for debounce
+ */
+
+Board.prototype.digitalReadDebounced = function( pin, callback, sens ) {
+
+    var  timeout     = false
+        ,sensitivity = sens || 70
+        ,last_sent   = null
+        ,last_value  = null;
+
+    this.pinMode( pin, this.MODES.INPUT );
+    this.digitalRead( pin, function( val ) {
+
+        if( timeout !== false ) {
+            clearTimeout( timeout );
+        }
+
+        timeout = setTimeout( function() {
+            timeout = false;
+
+            if( last_value != last_sent ) {
+                callback( last_value );
+            }
+
+            last_sent = last_value;
+        }, sensitivity );
+
+        last_value = val;
+    });
+};
+
+
+/**
  * Asks the arduino to tell us its capabilities
  * @param {function} callback A function to call when we receive the capabilities
  */


### PR DESCRIPTION
I thought it could be nice if this firmata library provides a native debounce function for digital inputs.
thats the function i use to debounce some push buttons or reed-contacts
