### PR TITLE
Fix: connection only works right after board boot

### DIFF
--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -377,12 +377,14 @@ var Board = function(port, callback) {
                 }
             }
         });
-        board.once('reportversion', function () {
-            board.versionReceived = true;
-            board.once('queryfirmware', function () {
-                board.queryCapabilities(function() {
-                    board.queryAnalogMapping(function() {
-                        callback();
+        this.sp.on('open', function() {
+            board.reportVersion(function () {
+                board.versionReceived = true;
+                board.queryFirmware(function() {
+                    board.queryCapabilities(function() {
+                        board.queryAnalogMapping(function() {
+                            callback();
+                        });
                     });
                 });
             });
@@ -397,7 +399,7 @@ util.inherits(Board, events.EventEmitter);
 
 Board.prototype.reportVersion = function(callback) {
     this.once('reportversion', callback);
-    this.sp.write(REPORT_VERSION);
+    this.sp.write([REPORT_VERSION]);
 };
 
 /**


### PR DESCRIPTION
Node-firmata initializes by waiting for a Version Report from the board. This is only sent automatically on boot. So unless rebooting the board after starting node-firmata, it will not connect. 
This is particularly painful with Arduino Leonardo, where the serial device disappears during reboot, so the only way to get it working is to start node-firmata after the bootloader has finished, but before the version report was sent (about 1 second window).
This diff fixes the above bug by sending a version report request and a firmware query when the serial port opens, and waiting for the response.
