### PR TITLE
Do not assume pins to be configured to OUTPUT initally in a capability-query response

### DIFF
--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -156,7 +156,7 @@ SYSEX_RESPONSE[CAPABILITY_RESPONSE] = function(board) {
             Object.keys(board.MODES).forEach(pushModes.bind(null, modesArray));
             board.pins.push({
                 supportedModes: modesArray,
-                mode: board.MODES.OUTPUT,
+                mode: board.MODES.UNKNOWN,
                 value : 0,
                 report: 1
             });
@@ -294,7 +294,8 @@ var Board = function(port, options, callback) {
             OUTPUT: 0x01,
             ANALOG: 0x02,
             PWM: 0x03,
-            SERVO: 0x04
+            SERVO: 0x04,
+            UNKNOWN: 0x10
         };
         this.I2C_MODES = {
             WRITE: 0x00,


### PR DESCRIPTION
While parsing a capability-query response: Do not set pin modes to board.MODES.OUTPUT initally but to board.MODES.UNKNOWN instead. Addresses #31.
