### PR TITLE
adds 1-wire support via ConfigurableFirmata

### DIFF
--- a/lib/encoder7bit.js
+++ b/lib/encoder7bit.js
@@ -1,0 +1,47 @@
+/**
+ * "Inspired" by Encoder7Bit.h/Encoder7Bit.cpp in the
+ * Firmata source code.
+ */
+module.exports = {
+    to7BitArray: function(data) {
+        var shift = 0;
+        var previous = 0;
+        var output = [];
+
+        data.forEach(function(byte) {
+            if (shift == 0) {
+                output.push(byte & 0x7f)
+                shift++;
+                previous = byte >> 7;
+            } else {
+                output.push(((byte << shift) & 0x7f) | previous);
+                if (shift == 6) {
+                    output.push(byte >> 1);
+                    shift = 0;
+                } else {
+                    shift++;
+                    previous = byte >> (8 - shift);
+                }
+            }
+        })
+
+        if (shift > 0) {
+            output.push(previous);
+        }
+
+        return output;
+    },
+    from7BitArray: function(encoded) {
+        var expectedBytes = (encoded.length) * 7 >> 3;
+        var decoded = [];
+
+        for (var i = 0; i < expectedBytes ; i++) {
+            var j = i << 3;
+            var pos = parseInt(j/7);
+            var shift = j % 7;
+            decoded[i] = (encoded[pos] >> shift) | ((encoded[pos+1] << (7 - shift)) & 0xFF);
+        }
+
+        return decoded;
+    }
+}

--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -8,7 +8,9 @@
 
 var SerialPort = require('serialport').SerialPort,
     util = require('util'),
-    events = require('events');
+    events = require('events'),
+    Encoder7Bit = require('./encoder7bit'),
+    OneWireUtils = require('./onewireutils');
 
 /**
  * constants
@@ -37,8 +39,20 @@ var PIN_MODE = 0xF4,
     PULSE_OUT = 0x73,
     PULSE_IN = 0x74,
     SAMPLING_INTERVAL = 0x7A,
-    STEPPER = 0x72;
+    STEPPER = 0x72,
+    ONEWIRE_DATA = 0x73,
 
+    ONEWIRE_CONFIG_REQUEST = 0x41,
+    ONEWIRE_SEARCH_REQUEST = 0x40,
+    ONEWIRE_SEARCH_REPLY = 0x42,
+    ONEWIRE_SEARCH_ALARMS_REQUEST = 0x44,
+    ONEWIRE_SEARCH_ALARMS_REPLY = 0x45,
+    ONEWIRE_READ_REPLY = 0x43,
+    ONEWIRE_RESET_REQUEST_BIT = 0x01,
+    ONEWIRE_READ_REQUEST_BIT = 0x08,
+    ONEWIRE_DELAY_REQUEST_BIT = 0x10,
+    ONEWIRE_WRITE_REQUEST_BIT = 0x20,
+    ONEWIRE_WITHDATA_REQUEST_BITS = 0x3C;
 
     /**
      * MIDI_RESPONSE contains functions to be called when we receive a MIDI message from the arduino.
@@ -228,6 +242,38 @@ SYSEX_RESPONSE[I2C_REPLY] = function(board) {
     board.emit('I2C-reply-' + slaveAddress, replyBuffer);
 };
 
+SYSEX_RESPONSE[ONEWIRE_DATA] = function(board) {
+    var subCommand = board.currentBuffer[2];
+
+    if(!SYSEX_RESPONSE[subCommand]) {
+        return;
+    }
+
+    SYSEX_RESPONSE[subCommand](board);
+};
+
+SYSEX_RESPONSE[ONEWIRE_SEARCH_REPLY] = function(board) {
+    var pin = board.currentBuffer[3];
+    var replyBuffer = board.currentBuffer.slice(4, board.currentBuffer.length -1);
+
+    board.emit('1-wire-search-reply-' + pin, OneWireUtils.readDevices(replyBuffer));
+}
+
+SYSEX_RESPONSE[ONEWIRE_SEARCH_ALARMS_REPLY] = function(board) {
+    var pin = board.currentBuffer[3];
+    var replyBuffer = board.currentBuffer.slice(4, board.currentBuffer.length -1);
+
+    board.emit('1-wire-search-alarms-reply-' + pin, OneWireUtils.readDevices(replyBuffer));
+}
+
+SYSEX_RESPONSE[ONEWIRE_READ_REPLY] = function(board) {
+    var encoded = board.currentBuffer.slice(4, board.currentBuffer.length -1);
+    var decoded = Encoder7Bit.from7BitArray(encoded);
+    var correlationId = (decoded[1] << 8) | decoded[0];
+
+    board.emit('1-wire-read-reply-' + correlationId, decoded.slice(2));
+}
+
 /**
  * Handles a STRING_DATA response and logs the string to the console.
  * @private
@@ -294,7 +340,12 @@ var Board = function(port, options, callback) {
             OUTPUT: 0x01,
             ANALOG: 0x02,
             PWM: 0x03,
-            SERVO: 0x04
+            SERVO: 0x04,
+            SHIFT: 0x05,
+            I2C: 0x06,
+            ONEWIRE: 0x07,
+            STEPPER: 0x08,
+            IGNORE: 0x7F
         };
         this.I2C_MODES = {
             WRITE: 0x00,
@@ -567,6 +618,169 @@ Board.prototype.sendI2CReadRequest = function(slaveAddress, numBytes, callback) 
     this.sp.write(new Buffer([START_SYSEX, I2C_REQUEST, slaveAddress, this.I2C_MODES.READ << 3, numBytes & 0x7F, (numBytes >> 7) & 0x7F, END_SYSEX]));
     this.once('I2C-reply-' + slaveAddress, callback);
 };
+
+/**
+ * Configure the passed pin as the controller in a 1-wire bus.
+ * Pass as enableParasiticPower true if you want the data pin to power the bus.
+ * @param pin
+ * @param enableParasiticPower
+ */
+Board.prototype.sendOneWireConfig = function(pin, enableParasiticPower) {
+    this.sp.write(new Buffer([START_SYSEX, ONEWIRE_DATA, ONEWIRE_CONFIG_REQUEST, pin, enableParasiticPower ? 0x01 : 0x00, END_SYSEX]));
+};
+
+/**
+ * Searches for 1-wire devices on the bus.  The passed callback should accept
+ * and error argument and an array of device identifiers.
+ * @param pin
+ * @param callback
+ */
+Board.prototype.sendOneWireSearch = function(pin, callback) {
+    this._sendOneWireSearch(ONEWIRE_SEARCH_REQUEST, '1-wire-search-reply-' + pin, pin, callback);
+};
+
+/**
+ * Searches for 1-wire devices on the bus in an alarmed state.  The passed callback
+ * should accept and error argument and an array of device identifiers.
+ * @param pin
+ * @param callback
+ */
+Board.prototype.sendOneWireAlarmsSearch = function(pin, callback) {
+    this._sendOneWireSearch(ONEWIRE_SEARCH_ALARMS_REQUEST, '1-wire-search-alarms-reply-' + pin, pin, callback);
+};
+
+Board.prototype._sendOneWireSearch = function(type, event, pin, callback) {
+    this.sp.write(new Buffer([START_SYSEX, ONEWIRE_DATA, type, pin, END_SYSEX]));
+
+    var searchTimeout = setTimeout(function() {
+        callback(new Error("1-Wire device search timeout - are you running ConfigurableFirmata?"))
+    }, 5000);
+    this.once(event, function(devices) {
+        clearTimeout(searchTimeout);
+
+        callback(null, devices);
+    });
+}
+
+/**
+ * Reads data from a device on the bus and invokes the passed callback.
+ *
+ * N.b. ConfigurableFirmata will issue the 1-wire select command internally.
+ * @param pin
+ * @param device
+ * @param numBytesToRead
+ * @param callback
+ */
+Board.prototype.sendOneWireRead = function(pin, device, numBytesToRead, callback) {
+    var correlationId = Math.floor(Math.random() * 255);
+    var readTimeout = setTimeout(function() {
+        callback(new Error("1-Wire device read timeout - are you running ConfigurableFirmata?"))
+    }, 5000);
+    this._sendOneWireRequest(pin, ONEWIRE_READ_REQUEST_BIT, device, numBytesToRead, correlationId, null, null, '1-wire-read-reply-' + correlationId, function(data) {
+        clearTimeout(readTimeout);
+
+        callback(null, data);
+    });
+};
+
+/**
+ * Resets all devices on the bus.
+ * @param pin
+ */
+Board.prototype.sendOneWireReset = function(pin) {
+    this._sendOneWireRequest(pin, ONEWIRE_RESET_REQUEST_BIT);
+};
+
+/**
+ * Writes data to the bus to be received by the passed device.  The device
+ * should be obtained from a previous call to sendOneWireSearch.
+ *
+ * N.b. ConfigurableFirmata will issue the 1-wire select command internally.
+ * @param pin
+ * @param device
+ * @param data
+ */
+Board.prototype.sendOneWireWrite = function(pin, device, data) {
+    this._sendOneWireRequest(pin, ONEWIRE_WRITE_REQUEST_BIT, device, null, null, null, Array.isArray(data) ? data : [data]);
+};
+
+/**
+ * Tells firmata to not do anything for the passed amount of ms.  For when you
+ * need to give a device attached to the bus time to do a calculation.
+ * @param pin
+ */
+Board.prototype.sendOneWireDelay = function(pin, delay) {
+    this._sendOneWireRequest(pin, ONEWIRE_DELAY_REQUEST_BIT, null, null, null, delay);
+};
+
+/**
+ * Sends the passed data to the passed device on the bus, reads the specified
+ * number of bytes and invokes the passed callback.
+ *
+ * N.b. ConfigurableFirmata will issue the 1-wire select command internally.
+ * @param pin
+ * @param device
+ * @param data
+ * @param numBytesToRead
+ * @param callback
+ */
+Board.prototype.sendOneWireWriteAndRead = function(pin, device, data, numBytesToRead, callback) {
+    var correlationId = Math.floor(Math.random() * 255);
+    var readTimeout = setTimeout(function() {
+        callback(new Error("1-Wire device read timeout - are you running ConfigurableFirmata?"))
+    }, 5000);
+    this._sendOneWireRequest(pin, ONEWIRE_WRITE_REQUEST_BIT | ONEWIRE_READ_REQUEST_BIT, device, numBytesToRead, correlationId, null, Array.isArray(data) ? data : [data], '1-wire-read-reply-' + correlationId, function(data) {
+        clearTimeout(readTimeout);
+
+        callback(null, data);
+    });
+};
+
+// see http://firmata.org/wiki/Proposals#OneWire_Proposal
+Board.prototype._sendOneWireRequest = function(pin, subcommand, device, numBytesToRead, correlationId, delay, dataToWrite, event, callback) {
+    var bytes = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+
+    if(device || numBytesToRead || correlationId || delay || dataToWrite) {
+        subcommand = subcommand | ONEWIRE_WITHDATA_REQUEST_BITS;
+    }
+
+    if(device) {
+        bytes.splice.apply(bytes, [0, 8].concat(device));
+    }
+
+    if(numBytesToRead) {
+        bytes[8] = numBytesToRead & 0xFF;
+        bytes[9] = (numBytesToRead >> 8) & 0xFF;
+    }
+
+    if(correlationId) {
+        bytes[10] = correlationId & 0xFF;
+        bytes[11] = (correlationId >> 8) & 0xFF;
+    }
+
+    if(delay) {
+        bytes[12] = delay & 0xFF;
+        bytes[13] = (delay >> 8) & 0xFF;
+        bytes[14] = (delay >> 16) & 0xFF;
+        bytes[15] = (delay >> 24) & 0xFF;
+    }
+
+    if(dataToWrite) {
+        dataToWrite.forEach(function(byte) {
+            bytes.push(byte);
+        });
+    }
+
+    var output = [START_SYSEX, ONEWIRE_DATA, subcommand, pin];
+    output = output.concat(Encoder7Bit.to7BitArray(bytes));
+    output.push(END_SYSEX);
+
+    this.sp.write(new Buffer(output));
+
+    if(event && callback) {
+        this.once(event, callback);
+    }
+}
 
 /**
  * Set sampling interval in millis. Default is 19 ms

--- a/lib/onewireutils.js
+++ b/lib/onewireutils.js
@@ -1,0 +1,48 @@
+var Encoder7Bit = require('./encoder7bit');
+
+OneWireUtils = {
+    crc8: function(data) {
+        var crc = 0;
+
+        for(var i = 0; i < data.length; i++) {
+            var inbyte = data[i];
+
+            for (var n = 8; n; n--) {
+                var mix = (crc ^ inbyte) & 0x01;
+                crc >>= 1;
+
+                if (mix) {
+                    crc ^= 0x8C;
+                }
+
+                inbyte >>= 1;
+            }
+        }
+        return crc;
+    },
+
+    readDevices: function(data) {
+        var deviceBytes = Encoder7Bit.from7BitArray(data);
+        var devices = [];
+
+        for(var i = 0; i < deviceBytes.length; i += 8) {
+            var device = deviceBytes.slice(i, i + 8);
+
+			if(device.length != 8) {
+				continue;
+			}
+
+            var check = OneWireUtils.crc8(device.slice(0, 7));
+
+            if(check != device[7]) {
+                console.error("ROM invalid!");
+            }
+
+            devices.push(device);
+        }
+
+        return devices;
+    }
+};
+
+module.exports = OneWireUtils;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "serialport": ">=0.7.5"
   },
   "scripts": {
-    "test": "mocha test/firmata.js"
+    "test": "mocha test/firmata.js test/encoder7bit.js test/onewireutils.js"
   },
   "engines": {
     "node": "*"

--- a/test/encoder7bit.js
+++ b/test/encoder7bit.js
@@ -1,0 +1,14 @@
+var should = require('should'),
+    Encoder7Bit = require('../lib/encoder7bit');
+
+describe('board', function () {
+    it('should encode and decode via in-memory array', function (done) {
+        var input = [40, 219, 239, 33, 5, 0, 0, 93, 0, 0, 0, 0, 0, 0, 0, 0];
+        var encoded = Encoder7Bit.to7BitArray(input);
+        var decoded = Encoder7Bit.from7BitArray(encoded);
+
+        decoded.should.eql(input);
+
+        done();
+    });
+});

--- a/test/onewireutils.js
+++ b/test/onewireutils.js
@@ -1,0 +1,45 @@
+var should = require('should'),
+    OneWireUtils = require('../lib/onewireutils');
+var Encoder7Bit = require('../lib/encoder7bit.js');
+describe('board', function () {
+    it('should CRC check data read from firmata', function (done) {
+        var input = [0x28, 0xDB, 0xEF, 0x21, 0x05, 0x00, 0x00, 0x5D];
+        var crcByte = OneWireUtils.crc8(input.slice(0, input.length - 1));
+
+        crcByte.should.equal(input[input.length - 1]);
+
+        done();
+    });
+    it('should return an invalid CRC check for corrupt data', function (done) {
+        var input = [0x28, 0xDB, 0xEF, 0x22, 0x05, 0x00, 0x00, 0x5D];
+        var crcByte = OneWireUtils.crc8(input.slice(0, input.length - 1));
+
+        crcByte.should.not.equal(input[input.length - 1]);
+
+        done();
+    });
+    it('should read device identifier', function (done) {
+        var input = Encoder7Bit.to7BitArray([0x28, 0xDB, 0xEF, 0x21, 0x05, 0x00, 0x00, 0x5D]);
+        var devices = OneWireUtils.readDevices(input);
+
+        devices.length.should.equal(1);
+
+        done();
+    });
+    it('should read device identifiers', function (done) {
+        var input = Encoder7Bit.to7BitArray([0x28, 0xDB, 0xEF, 0x21, 0x05, 0x00, 0x00, 0x5D, 0x28, 0xDB, 0xEF, 0x21, 0x05, 0x00, 0x00, 0x5D]);
+        var devices = OneWireUtils.readDevices(input);
+
+        devices.length.should.equal(2);
+
+        done();
+    });
+    it('should read only complete device identifiers', function (done) {
+        var input = Encoder7Bit.to7BitArray([0x28, 0xDB, 0xEF, 0x21, 0x05, 0x00, 0x00, 0x5D, 0x28, 0xDB, 0xEF, 0x21, 0x05, 0x00, 0x00, 0x5D, 0x00, 0x01, 0x02]);
+        var devices = OneWireUtils.readDevices(input);
+
+        devices.length.should.equal(2);
+
+        done();
+    });
+});


### PR DESCRIPTION
I bought a [SparkFun DS18B20 based waterproof temperature sensor](http://proto-pic.co.uk/temperature-sensor-waterproof-ds18b20/), foolishly thinking it'd be as easy to use as the [TMP36](https://www.sparkfun.com/products/10988) sensor they include in their Inventors Kit.

Turns out it's a digital sensor that talks [1-Wire](http://en.wikipedia.org/wiki/1-Wire) - a bus protocol for connecting multiple sensors in series.

StandardFirmata does not support 1-Wire, but as luck would have it [ConfigurableFirmata](https://github.com/firmata/arduino/tree/configurable) does (see [the proposal](http://firmata.org/wiki/Proposals#OneWire_Proposal) and [the implementation](https://github.com/firmata/arduino/blob/configurable/utility/OneWireFirmata.cpp)).

This pull request adds support for 1-Wire, on the assumption that you've flashed your board with ConfigurableFirmata.  If you haven't, it tries to detect this by printing out an error asking the user if they've done that if appropriate responses are not received from the attached device when searching for 1-Wire devices on the bus within a reasonable timeframe.

With the code in this pull request I can now use the DS18B20 like so:

``` javascript
var board = new firmata.Board("/dev/my/device", function (error) {
  if(error) {
    console.error(error);
    return;
  }

  // 1-wire devices are on pin 7
  var pin = 7;

  board.sendOneWireConfig(pin, true);
  board.sendOneWireSearch(pin, function(error, devices) {
    if(error) {
      console.error(error);
      return;
    }

    // only interested in the first device
    var device = devices[0];

    var readTemperature = function() {
      // start transmission
      board.sendOneWireReset(pin);

      // a 1-wire select is done by ConfigurableFirmata
      board.sendOneWireWrite(pin, device, 0x44);

      // the delay gives the sensor time to do the calculation
      board.sendOneWireDelay(pin, 1000);

      // start transmission
      board.sendOneWireReset(pin);

      // tell the sensor we want the result and read it from the scratchpad
      board.sendOneWireWriteAndRead(pin, device, 0xBE, 9, function(error, data) {
        if(error) {
          console.error(error);
          return;
        }

        var raw = (data[1] << 8) | data[0];
        var celsius = raw / 16.0;
        var fahrenheit = celsius * 1.8 + 32.0;

        console.info("celsius", celsius);
        console.info("fahrenheit", fahrenheit);
      });
    };

    // read the temperature now
    readTemperature();

    // and every five seconds
    setInterval(readTemperature, 5000);
  });
});
```

I've included tests for the new code introduced.  Happy to discuss any aspect of the changes.

One problem I think is that 1-Wire is ConfigurableFirmata but not in StandardFirmata, but hopefully we can work something out.
