### PR TITLE
Check for out of sync data bytes

### DIFF
--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -432,10 +432,10 @@ var Board = function(port, options, callback) {
                 // Check if data gets out of sync (first byte in buffer must be a valid command if not START_SYSEX)
                 else if (board.currentBuffer[0] !== START_SYSEX) {
                     // Identify command on first byte
-                    cmd = board.currentBuffer[0] < 240 ? board.currentBuffer[0] & 0xF0 : board.currentBuffer[0]
+                    cmd = board.currentBuffer[0] < 240 ? board.currentBuffer[0] & 0xF0 : board.currentBuffer[0];
                     
                     // Check if it is not a valid command
-                    if (cmd != REPORT_VERSION && cmd != ANALOG_MESSAGE && cmd != DIGITAL_MESSAGE) {
+                    if (cmd !== REPORT_VERSION && cmd !== ANALOG_MESSAGE && cmd !== DIGITAL_MESSAGE) {
                         // console.log("OUT OF SYNC - CMD: "+cmd);
                         // Clean buffer
                         board.currentBuffer.length = 0;


### PR DESCRIPTION
Check if the first byte on board.currentBuffer corresponds to a valid
command.  If not clear the buffer to prevent errors due to out of sync
data (this might happens on small boards - such as Raspberry Pi - when
cpu intensive processes ar run)
