### PR TITLE
Work around for chrome's special reassign protection 

### DIFF
--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -8,10 +8,10 @@
 
 var util = require('util'),
     events = require('events'),
-    chromeRef = typeof chrome == "object" ? chrome : undefined,
     Encoder7Bit = require('./encoder7bit'),
     OneWireUtils = require('./onewireutils'),
-    SerialPort = null;
+    SerialPort = null,
+    chromeRef = typeof chrome === "object" ? chrome : undefined;
 
 try {
     if (typeof chromeRef !== "undefined" && chromeRef.serial) {


### PR DESCRIPTION
Turns out that chrome has a protection against assigning the 'chrome' object to something else (and itself) and will change it to undefined instead. So that change for jshint broke it. Sorry @jgautier
