### PR TITLE
remove uncessary firmata traffic

### DIFF
--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -358,7 +358,7 @@ var Board = function(port, options, callback) {
         };
     }
     var board = this;
-    board.options = options;
+    this.options = options;
     this.MODES = {
         INPUT: 0x00,
         OUTPUT: 0x01,


### PR DESCRIPTION
Currently it is difficult to use firmata.js with traffic over slower serial transports such as binary websockets.

This change only asks to reporting on existing pins and optionally turns down the sampleInterval before requesting data.
