### PR TITLE
Fix options check

### DIFF
--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -349,7 +349,7 @@ SYSEX_RESPONSE[STEPPER] = function (board) {
  */
 var Board = function(port, options, callback) {
     events.EventEmitter.call(this);
-    if (typeof options === 'function') {
+    if (typeof options === 'function' || typeof options === 'undefined') {
         callback = options;
         options = {
             reportVersionTimeout: 5000


### PR DESCRIPTION
This prevents an error from being thrown when constructor called with only device path.

Signed-off-by: Rick Waldron waldron.rick@gmail.com
