### PR TITLE
delay open serialport to trap errors

### DIFF
--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -411,15 +411,15 @@ var Board = function(port, options, callback) {
             baudrate: 57600,
             buffersize: 1
         }, false);
+
+        this.sp.on('error', function(string) {
+            if (typeof callback === 'function') {
+                callback(string);
+            }
+        });
+
+        this.sp.open()
     }
-
-    this.sp.on('error', function(string) {
-        if (typeof callback === 'function') {
-            callback(string);
-        }
-    });
-
-    this.sp.open()
 
     this.sp.on('data', function(data) {
         var byt, cmd;

--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -418,7 +418,7 @@ var Board = function(port, options, callback) {
             }
         });
 
-        this.sp.open()
+        this.sp.open();
     }
 
     this.sp.on('data', function(data) {

--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -410,7 +410,7 @@ var Board = function(port, options, callback) {
         this.sp = new SerialPort(port, {
             baudrate: 57600,
             buffersize: 1
-        });
+        }, false);
     }
 
     this.sp.on('error', function(string) {
@@ -418,6 +418,8 @@ var Board = function(port, options, callback) {
             callback(string);
         }
     });
+
+    this.sp.open()
 
     this.sp.on('data', function(data) {
         var byt, cmd;


### PR DESCRIPTION
On Mac OSX, when the serial port is not available the error is not trapped and the process exits. These changes delay opening the SP until the error handler is in place.