### PR TITLE
Fix digital report

### DIFF
--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -175,10 +175,6 @@ SYSEX_RESPONSE[QUERY_FIRMWARE] = function (board) {
 SYSEX_RESPONSE[CAPABILITY_RESPONSE] = function (board) {
     var supportedModes = 0;
 
-    if (board.options.samplingInterval){
-        board.setSamplingInterval(board.options.samplingInterval);
-    }
-
     function pushModes(modesArray, mode) {
         if (supportedModes & (1 << board.MODES[mode])) {
             modesArray.push(board.MODES[mode]);


### PR DESCRIPTION
Theres a bug in current release mistakes pins for port in digital report. 

Further more the existing code actually set the pins several times for some reason 
D0 01 D1 01 D2 01 D3 01 D4 01 D5 01 D6 01 D7 01 D8 01 D9 01 DA 01 DB 01 DC 01 DD 01 DE 01 DF 01 D0 01 D1 01 D2 01 D3 01

Generally speaking, port would 0 contains pins D0-D7

You would send 0xD0 0x00 to set all pins on port 0 off, or 0xD0 0xFF to set all pins on.

This requires you maintain an internal state of pins (which you already do) and send the neighbor pins on that port or know that you're altering their state.

So I've created a _getPortValue function to generate that state so we can safely set pins.

I've left the digital report on startup commented because at this point its probably a breaking change. Also changed the default report to 0 to reflect the fact that reporting isnt (and has never been) on by default.

Please accept https://github.com/jgautier/firmata/issues/62 and https://github.com/jgautier/firmata/issues/58 I need them for my work.
