### PR TITLE
Added a check for pin numbers not divisible by 8.

### DIFF
--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -611,8 +611,10 @@ Board.prototype.digitalWrite = function (pin, value) {
     var portValue = 0;
     this.pins[pin].value = value;
     for (var i = 0; i < 8; i++) {
-        if (this.pins[8 * port + i].value) {
-            portValue |= (1 << i);
+        if (this.pins[8 * port + i]) {
+            if (this.pins[8 * port + i].value) {
+                portValue |= (1 << i);
+            }
         }
     }
     this.sp.write(new Buffer([DIGITAL_MESSAGE | port, portValue & 0x7F, (portValue >> 7) & 0x7F]));


### PR DESCRIPTION
I am working on bringing Firmata to TI LaunchPads. Since the LaunchPads has Energia support, a fork of Arduino, I am able to easily load the devices with Firmata sketches.

In the process, I got an error for having pin numbers not divisible by 8. Let's say I have 41 pins total. In digitialWrite(), if pin=41, then port would equal to 5. When iterating through the for loop, this.pins[42] would not be defined, so this.pins[42].value would cause an error.

I got a workaround by doing a simple check  "if (this.pins[8 * port + i])" is valid. This would not change any existing functionality, but it would allow pin numbers not divisible by 8. 

You can check out my FirmataGUI using your module on my GitHub. Here is a picture of what it looks like http://boosterbot.in/images/software-firmata-pin.jpg