### PR TITLE
Use object-assign module as replacement for es6-shim

### DIFF
--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -1,4 +1,5 @@
-require("es6-shim");
+var assign = require("object-assign");
+
 /**
  * @author Julian Gautier
  */
@@ -366,7 +367,7 @@ var Board = function(port, options, callback) {
   }
 
   var board = this;
-  var settings = Object.assign({}, defaults, options);
+  var settings = assign({}, defaults, options);
 
   var ready = function() {
     this.emit("ready");

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "browser-serialport": "*",
-    "es6-shim": "^0.20.2",
+    "object-assign": "^1.0.0",
     "serialport": ">=0.7.5"
   },
   "optionalDependencies": {},


### PR DESCRIPTION
This corrects an issue running firmata inside of a Chrome App, where es6-shim conflicted with Chrome's CSP.

Specifically, [this line](https://github.com/paulmillr/es6-shim/blob/master/es6-shim.js#L72) was the culprit.

This could be worked around with sandboxing, but that disables all `chrome.*` APIs, making `browser-serialport` non-functional.

To fix the issue, and since only one ES6 feature was used (`Object#assign`), I've added Sindre Sorhus's `object-assign` ponyfill.

If in the future more ES6 methods are used, another solution might be found (or a patch submitted to es6-shims).

Please let me know if there's anything wrong with this patch, and I'll try to get any issues fixed.
