### PR TITLE
enable user to update baud of configured Serial port

### DIFF
--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -83,6 +83,7 @@ var SERIAL_REPLY = 0x40;
 var SERIAL_CLOSE = 0x50;
 var SERIAL_FLUSH = 0x60;
 var SERIAL_LISTEN = 0x70;
+var SERIAL_UPDATE_BAUD = 0x80;
 var START_SYSEX = 0xF0;
 var STEPPER = 0x72;
 var STRING_DATA = 0x71;
@@ -1651,6 +1652,26 @@ Board.prototype.serialListen = function(portId) {
     START_SYSEX,
     SERIAL_MESSAGE,
     SERIAL_LISTEN | portId,
+    END_SYSEX
+  ];
+  this.transport.write(new Buffer(data));
+};
+
+/**
+ * Update the baud rate of a configured serial port. Note that there is a 100ms delay required
+ * to update the baud in the firmware plus additional time to transmit this command. Wait a minimum
+ * of 200ms before writing to the serial port after calling this method.
+ * @param {number} portId The serial port to update the baud of.
+ * @param {number} newBaud The new baud rate to set.
+ */
+Board.prototype.serialBaud = function(portId, newBaud) {
+  var data = [
+    START_SYSEX,
+    SERIAL_MESSAGE,
+    SERIAL_UPDATE_BAUD | portId,
+    newBaud & 0x007F,
+    (newBaud >> 7) & 0x007F,
+    (newBaud >> 14) & 0x007F,
     END_SYSEX
   ];
   this.transport.write(new Buffer(data));

--- a/test/firmata.test.js
+++ b/test/firmata.test.js
@@ -54,6 +54,7 @@ var SERIAL_REPLY = 0x40;
 var SERIAL_CLOSE = 0x50;
 var SERIAL_FLUSH = 0x60;
 var SERIAL_LISTEN = 0x70;
+var SERIAL_UPDATE_BAUD = 0x80;
 var START_SYSEX = 0xF0;
 var STEPPER = 0x72;
 var STRING_DATA = 0x71;
@@ -1602,6 +1603,15 @@ describe("board", function() {
     board.serialListen(0x01);
     should.equal(spy.callCount, 0);
     spy.restore();
+    done();
+  });
+
+  it("has a serialBaud method for updating the baud rate", function (done) {
+    board.serialBaud(0x08, 38400);
+    serialPort.lastWrite[2].should.equal(SERIAL_UPDATE_BAUD | 0x08);
+    serialPort.lastWrite[3].should.equal(38400 & 0x007F);
+    serialPort.lastWrite[4].should.equal((38400 >> 7) & 0x007F);
+    serialPort.lastWrite[5].should.equal((38400 >> 14) & 0x007F);
     done();
   });
 


### PR DESCRIPTION
The delay here could be tricky. Users have to understand that if they call `board.serialBaud(newBaudRate)` they will need to wait at least 200ms before they can write to the serial port.

The delay is necessary for updating the baud rate for HW serial. There is actually no delay (other than the time required to transmit the command to the Arduino) for SW serial, but it's probably easier to say the delay exists regardless.
