### PR TITLE
Timeout to first write

### DIFF
--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -418,7 +418,7 @@ function Board(port, options, callback) {
   var defaults = {
     reportVersionTimeout: 5000,
     samplingInterval: 19,
-    firstWriteTimeout: 1000,
+    firstWriteTimeout: 2000,
     serialport: {
       baudRate: 57600,
       bufferSize: 256,

--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -418,6 +418,7 @@ function Board(port, options, callback) {
   var defaults = {
     reportVersionTimeout: 5000,
     samplingInterval: 19,
+    firstWriteTimeout: 1000,
     serialport: {
       baudRate: 57600,
       bufferSize: 256,
@@ -686,11 +687,15 @@ function Board(port, options, callback) {
             this.pins.push({supportedModes: [], analogChannel: analogChannel});
           }
         }
-        ready();
+        setTimeout(function() {
+          ready();
+        }, settings.firstWriteTimeout);
       } else {
-        this.queryCapabilities(function() {
-          this.queryAnalogMapping(ready);
-        });
+        setTimeout(function() {
+          this.queryCapabilities(function() {
+            this.queryAnalogMapping(ready);
+          });
+        }.bind(this), settings.firstWriteTimeout);
       }
     });
   });

--- a/test/unit/firmata.test.js
+++ b/test/unit/firmata.test.js
@@ -611,7 +611,7 @@ describe("Board: lifecycle", function() {
   var initNoop = sandbox.spy();
 
   var transport = new SerialPort("/path/to/fake/usb");
-  var board = new Board(transport, initCallback);
+  var board = new Board(transport, {firstWriteTimeout: 0}, initCallback);
 
 
   beforeEach(function() {
@@ -907,6 +907,7 @@ describe("Board: lifecycle", function() {
     var transport = new SerialPort("/path/to/fake/usb");
     var options = {
       skipCapabilities: true,
+      firstWriteTimeout: 0
     };
 
     var board = new Board(transport, options, function() {

--- a/test/unit/firmata.test.js
+++ b/test/unit/firmata.test.js
@@ -702,7 +702,7 @@ describe("Board: lifecycle", function() {
 
   it("emits 'ready' after handshakes complete (skipCapabilities)", function(done) {
     var transport = new SerialPort("/path/to/fake/usb");
-    var board = new Board(transport, {skipCapabilities: true}, initNoop);
+    var board = new Board(transport, {skipCapabilities: true, firstWriteTimeout: 0}, initNoop);
     var oc = 0;
 
     board.on("open", function() {
@@ -728,7 +728,7 @@ describe("Board: lifecycle", function() {
 
   it("emits 'ready' after handshakes complete", function(done) {
     var transport = new SerialPort("/path/to/fake/usb");
-    var board = new Board(transport, initNoop);
+    var board = new Board(transport, {firstWriteTimeout: 0}, initNoop);
     var oc = 0;
 
     board.on("open", function() {
@@ -750,8 +750,10 @@ describe("Board: lifecycle", function() {
     transport.emit("open");
     board.emit("reportversion");
     board.emit("queryfirmware");
-    board.emit("capability-query");
-    board.emit("analog-mapping-query");
+    setTimeout(function() {
+      board.emit("capability-query");
+      board.emit("analog-mapping-query");
+    }, board.settings.firstWriteTimeout);
   });
 
   it("reports errors during connect/ready", function(done) {
@@ -876,7 +878,8 @@ describe("Board: lifecycle", function() {
     var transport = new SerialPort("/path/to/fake/usb");
     var options = {
       skipCapabilities: true,
-      samplingInterval: 100
+      samplingInterval: 100,
+      firstWriteTimeout: 0
     };
 
     var board = new Board(transport, options, function(err) {
@@ -1175,7 +1178,7 @@ describe("Board: lifecycle", function() {
 
   it("must be able to read value of analog pin on a board that skipped capabilities check", function(done) {
     var transport = new SerialPort("/path/to/fake/usb");
-    var board = new Board(transport, {skipCapabilities: true, analogPins: [14,15,16,17,18,19]}, initNoop);
+    var board = new Board(transport, {skipCapabilities: true, analogPins: [14,15,16,17,18,19], firstWriteTimeout: 0}, initNoop);
 
     board.on("ready", function() {
       var counter = 0;
@@ -1398,7 +1401,7 @@ describe("Board: lifecycle", function() {
 
   it("must be able to write a value to a digital output to a board that skipped capabilities check", function(done) {
     var transport = new SerialPort("/path/to/fake/usb");
-    var board = new Board(transport, {skipCapabilities: true}, initNoop);
+    var board = new Board(transport, {skipCapabilities: true, firstWriteTimeout: 0}, initNoop);
 
     board.on("ready", function() {
       board.digitalWrite(3, board.HIGH);


### PR DESCRIPTION
Sometimes, after open and before ready, the board does not respond to command _queryCapabilities_ (_settings.skipCapabilities_ is false). Adding a timeout before execute any write can prevent this issue. I don't know the exact time but PyMata3 uses 2 seconds (by default) after connected.

I created a new option _firstWriteTimeout_ to control timeout (default is 2000ms)
