### PR TITLE
Adding PIN_MODE_PULLUP definition

### DIFF
--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -439,6 +439,7 @@ function Board(port, options, callback) {
     ONEWIRE: 0x07,
     STEPPER: 0x08,
     SERIAL: 0x0A,
+    PULLUP: 0x0B,
     IGNORE: 0x7F,
     PING_READ: 0x75,
     UNKOWN: 0x10,


### PR DESCRIPTION
In [Firmata.h - line 106](https://github.com/firmata/arduino/blob/master/Firmata.h#L106) there is the PIN_MODE_PULLUP definition.
But in [firmata.js - lines 431-445](https://github.com/firmata/firmata.js/blob/master/lib/firmata.js#L431-L445) there isn't this definition.

Also, there isn't PIN_MODE_ENCODER definition, but I haven't seen this mode in any Firmata.ino file.

In [StandardFirmata.ino Capability_Query definition](https://github.com/firmata/arduino/blob/master/examples/StandardFirmata/StandardFirmata.ino#L607), all digital pins have Output, Input and Pullup supportedModes... but Firmata.js can't read this.

----

Test with an Arduino UNO board with StandarFirmata:
  - With actual Firmata.js **board.pins[3].supportedModes=0,1,3,4,5**
  - Adding PIN_MODE_PULLUP definition  **board.pins[3].supportedModes=0,1,3,4,5,11**