### PR TITLE
Test Upgrade to Serialport 4x

### DIFF
--- a/lib/com.js
+++ b/lib/com.js
@@ -26,25 +26,23 @@ Mock.prototype.close = function () {
   this.isClosed = true;
 };
 
-
-var stub = {
-  SerialPort: Mock,
-  list: function() {},
-};
+Mock.list = function() {};
 
 var com;
 
 try {
   if (process.browser || parseFloat(process.versions.nw) >= 0.13) {
-    com = require("browser-serialport");
+    var browserSerialport = require("browser-serialport");
+    com = browserSerialport.SerialPort;
+    com.list = browserSerialport.list;
   } else {
-    com = global.IS_TEST_MODE ? stub : require("serialport");
+    com = global.IS_TEST_MODE ? Mock : require("serialport");
   }
 } catch (err) {}
 
 if (com == null) {
   if (global.IS_TEST_MODE) {
-    com = stub;
+    com = Mock;
   } else {
     console.log("It looks like serialport didn't compile properly. This is a common problem and its fix is well documented here https://github.com/voodootikigod/node-serialport#to-install");
     throw "Missing serialport dependency";

--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -10,7 +10,7 @@ var Emitter = require("events").EventEmitter;
 // Internal Dependencies
 var Encoder7Bit = require("./encoder7bit");
 var OneWireUtils = require("./onewireutils");
-var com = require("./com");
+var SerialPort = require("./com");
 
 // Program specifics
 var i2cActive = new Map();
@@ -519,7 +519,7 @@ function Board(port, options, callback) {
   if (typeof port === "object") {
     this.transport = port;
   } else {
-    this.transport = new com.SerialPort(port, settings.serialport);
+    this.transport = new SerialPort(port, settings.serialport);
   }
 
   // For backward compat
@@ -1920,7 +1920,7 @@ Board.isAcceptablePort = function(port) {
  */
 
 Board.requestPort = function(callback) {
-  com.list(function(error, ports) {
+  SerialPort.list(function(error, ports) {
     var port = ports.find(function(port) {
       if (Board.isAcceptablePort(port)) {
         return port;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "browser-serialport": "*",
     "es6-shim": "^0.33.6",
-    "serialport": "^3.0.0"
+    "serialport": "4.0.0-rc1"
   },
   "scripts": {
     "test": "grunt",

--- a/test/common/bootstrap.js
+++ b/test/common/bootstrap.js
@@ -15,7 +15,7 @@ global.webpack = require("webpack");
 // Internal Dependencies
 global.Encoder7Bit = require("../../lib/encoder7bit");
 global.OneWire = require("../../lib/onewireutils");
-global.com = require("../../lib/com");
+global.SerialPort = require("../../lib/com");
 global.firmata = process.env.FIRMATA_COV ?
   require("../../lib-cov/firmata") :
   require("../../lib/firmata");

--- a/test/unit/firmata.test.js
+++ b/test/unit/firmata.test.js
@@ -67,7 +67,7 @@ describe("Board.requestPort", function() {
   };
 
   beforeEach(function() {
-    sandbox.stub(com, "list", function(callback) {
+    sandbox.stub(SerialPort, "list", function(callback) {
       process.nextTick(function() {
         callback(response.error, [response.port]);
       });
@@ -153,8 +153,8 @@ describe("Board: data handling", function() {
 
   beforeEach(function() {
     initCallback = sandbox.spy();
-    SerialPort = sandbox.spy(com, "SerialPort");
     transportWrite = sandbox.spy(SerialPort.prototype, "write");
+    SerialPort = sandbox.spy(SerialPort);
     transport = new SerialPort("/path/to/fake/usb");
     board = new Board(transport, initCallback);
   });
@@ -603,7 +603,7 @@ describe("Board: initialization", function() {
 
 describe("Board: lifecycle", function() {
 
-  var SerialPort = sandbox.spy(com, "SerialPort");
+  var SerialPort = sandbox.spy(SerialPort);
   var transportWrite = sandbox.spy(SerialPort.prototype, "write");
   var initCallback = sandbox.spy(function(error) {
     assert.equal(typeof error, "undefined");
@@ -617,7 +617,7 @@ describe("Board: lifecycle", function() {
   beforeEach(function() {
     Board.test.i2cActive.clear();
 
-    transport.spy = sandbox.spy(com, "SerialPort");
+    transport.spy = sandbox.spy(SerialPort);
 
     board._events.length = 0;
   });


### PR DESCRIPTION
To be used in testing. By the 4.0.0 release I hope to have browser serialport in parity.

SerialPort `4.0.0-rc1` is out and brings performance improvements, bug fixes and a few changes to the api. It's now out of sync with `browser-serialport` but not in a major way. https://github.com/garrows/browser-serialport/issues/40

I suspect this upgrade won't have any far reaching unattended effects as firmata uses only a fraction of the functions of SerialPort by default. The coms changes will be cleaner when browser serial port catches up.