### PR TITLE
Fixed "Cannot set property 'analogChannel' of undefined"

### DIFF
--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -265,9 +265,11 @@ SYSEX_RESPONSE[ANALOG_MAPPING_RESPONSE] = function(board) {
   var currentValue;
   for (var i = 2; i < board.currentBuffer.length - 1; i++) {
     currentValue = board.currentBuffer[i];
-    board.pins[pin].analogChannel = currentValue;
-    if (currentValue !== 127) {
-      board.analogPins.push(pin);
+    if ( board.pins[pin] ) {
+      board.pins[pin].analogChannel = currentValue;
+      if (currentValue !== 127) {
+        board.analogPins.push(pin);
+      }
     }
     pin++;
   }


### PR DESCRIPTION
```
/app/node_modules/johnny-five/node_modules/firmata/lib/firmata.js:269
      board.pins[pin].analogChannel = currentValue;
                                    ^

TypeError: Cannot set property 'analogChannel' of undefined
    at SYSEX_RESPONSE.(anonymous function) (/app/node_modules/johnny-five/node_modules/firmata/lib/firmata.js:269:37)
    at Board.<anonymous> (/app/node_modules/johnny-five/node_modules/firmata/lib/firmata.js:576:13)
    at emitOne (events.js:77:13)
    at SerialPort.emit (events.js:169:7)
    at SerialPort.module.exports.raw (/app/node_modules/johnny-five/node_modules/serialport/lib/parsers.js:7:13)
    at SerialPort._emitData (/app/node_modules/johnny-five/node_modules/serialport/lib/serialport.js:313:18)
    at SerialPort.<anonymous> (/app/node_modules/johnny-five/node_modules/serialport/lib/serialport.js:293:14)
    at SerialPort.<anonymous> (/app/node_modules/johnny-five/node_modules/serialport/lib/serialport.js:306:7)
    at FSReqWrap.wrapper [as oncomplete] (fs.js:576:17)
```