### PR TITLE
proposed changes to serial config and usage docs, closes #141

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -307,7 +307,7 @@ If you run *firmata* from the command line it will prompt you for the serial por
 
   ```
   options = {
-    portId: 1,      // <number> The serial port to use (HW_SERIAL1, HW_SERIAL2... )
+    portId: board.SERIAL_PORT_IDs.HW_SERIAL1, // <number> The serial port to use (HW_SERIAL2, SW_SERIAL0, SW_SERIAL1...)
     baud:   115200, // <number> (optional) The baud rate of the serial port; default is 57600
     rxPin:  5,      // <number> (optional)[SW Serial only] The RX pin of the SoftwareSerial instance
     txPin:  6       // <number> (optional)[SW Serial only] The TX pin of the SoftwareSerial instance

--- a/readme.md
+++ b/readme.md
@@ -303,19 +303,14 @@ If you run *firmata* from the command line it will prompt you for the serial por
 
 - `board.serialConfig(options)`
 
-  Configure a hardware or serial port
+  Configure a hardware or serial port -- required before using serial read/write functions
 
   ```
-  options {
-    portId {number}
-      The serial port to use
-      (HW_SERIAL1, HW_SERIAL2, HW_SERIAL3, SW_SERIAL0, SW_SERIAL1, SW_SERIAL2, SW_SERIAL3)
-    baud {number}
-      The baud rate of the serial port
-    rxPin {number}
-      [SW Serial only] The RX pin of the SoftwareSerial instance
-    txPin {number}
-      [SW Serial only] The TX pin of the SoftwareSerial instance
+  options = {
+    portId: 1,      // <number> The serial port to use (HW_SERIAL1, HW_SERIAL2... )
+    baud:   115200, // <number> (optional) The baud rate of the serial port; default is 57600
+    rxPin:  5,      // <number> (optional)[SW Serial only] The RX pin of the SoftwareSerial instance
+    txPin:  6       // <number> (optional)[SW Serial only] The TX pin of the SoftwareSerial instance
   }
   ```
 


### PR DESCRIPTION
Not sure of your preferences, but tried to balance parse-able JSON in the example with clear/thorough commenting. But this meant each comment needed to be shorter to not wrap or get cut off on narrower screens. 

I think this makes firmata.js easier to use for newcomers; open to suggestions and many thanks!