### PR TITLE
Adds log of require() error

### DIFF
--- a/lib/com.js
+++ b/lib/com.js
@@ -54,6 +54,7 @@ if (com == null) {
     com = stub;
   } else {
     console.log("It looks like serialport didn't compile properly. This is a common problem and its fix is well documented here https://github.com/voodootikigod/node-serialport#to-install");
+    console.log("The result of requiring the package is: ", sp);
     throw "Missing serialport dependency";
   }
 }


### PR DESCRIPTION
This edit just adds a line logging the error when requiring serialport fails. Otherwise it disappears into the ether, which can be problematic when the problem is not addressed by the installation link. I am open to better ways to do this, too. 😸 