### PR TITLE
Expose bit resolution of ADC, PWM (and others as available)

### DIFF
--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -193,6 +193,7 @@ SYSEX_RESPONSE[QUERY_FIRMWARE] = function(board) {
  */
 
 SYSEX_RESPONSE[CAPABILITY_RESPONSE] = function(board) {
+  var mode, resolution;
   var modes = Object.keys(board.MODES).map(function(key) {
     return board.MODES[key];
   });
@@ -222,7 +223,24 @@ SYSEX_RESPONSE[CAPABILITY_RESPONSE] = function(board) {
         continue;
       }
       if (n === 0) {
-        capability |= (1 << board.currentBuffer[i]);
+        mode = board.currentBuffer[i];
+        resolution = (1 << board.currentBuffer[i + 1]) - 1;
+        capability |= (1 << mode);
+
+        // ADC Resolution of Analog Inputs
+        if (mode === board.MODES.ANALOG && board.RESOLUTION.ADC === null) {
+          board.RESOLUTION.ADC = resolution;
+        }
+
+        // PWM Resolution of PWM Outputs
+        if (mode === board.MODES.PWM && board.RESOLUTION.PWM === null) {
+          board.RESOLUTION.PWM = resolution;
+        }
+
+        // DAC Resolution of DAC Outputs
+        // if (mode === board.MODES.DAC && board.RESOLUTION.DAC === null) {
+        //   board.RESOLUTION.DAC = resolution;
+        // }
       }
       n ^= 1;
     }
@@ -503,6 +521,12 @@ function Board(port, options, callback) {
     RES_TX2: 0x05,
     RES_RX3: 0x06,
     RES_TX3: 0x07,
+  };
+
+  this.RESOLUTION = {
+    ADC: null,
+    DAC: null,
+    PWM: null,
   };
 
   this.HIGH = 1;

--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -711,6 +711,15 @@ function Board(port, options, callback) {
             this.pins.push({supportedModes: [], analogChannel: analogChannel});
           }
         }
+
+        // If the capabilities query is skipped,
+        // default resolution values will be used.
+        //
+        // Based on ATmega328/P
+        //
+        this.RESOLUTION.ADC = 0x3FF;
+        this.RESOLUTION.PWM = 0x0FF;
+
         ready();
       } else {
         this.queryCapabilities(function() {
@@ -759,12 +768,12 @@ Board.prototype.analogRead = function(pin, callback) {
 };
 
 /**
- * Asks the arduino to write an analog message.
+ * Write a PWM value Asks the arduino to write an analog message.
  * @param {number} pin The pin to write analog data to.
- * @param {nubmer} value The data to write to the pin between 0 and 255.
+ * @param {nubmer} value The data to write to the pin between 0 and this.RESOLUTION.PWM.
  */
 
-Board.prototype.analogWrite = function(pin, value) {
+Board.prototype.pwmWrite = function(pin, value) {
   var data = [];
 
   this.pins[pin].value = value;
@@ -796,7 +805,7 @@ Board.prototype.analogWrite = function(pin, value) {
   this.transport.write(new Buffer(data));
 };
 
-Board.prototype.pwmWrite = Board.prototype.analogWrite;
+Board.prototype.analogWrite = Board.prototype.pwmWrite;
 
 /**
  * Set a pin to SERVO mode with an explicit PWM range.

--- a/test/unit/firmata.test.js
+++ b/test/unit/firmata.test.js
@@ -1026,6 +1026,12 @@ describe("Board: lifecycle", function() {
     transport.emit("data", [END_SYSEX]);
   });
 
+  it("board.RESOLUTION.* properties have values via CAPABILITY_RESPONSE", function(done) {
+    assert.equal(board.RESOLUTION.ADC, 1023);
+    assert.equal(board.RESOLUTION.PWM, 255);
+    done();
+  });
+
 
   it("querys analog mappings after capabilities", function(done) {
     //[START_SYSEX, ANALOG_MAPPING_QUERY, END_SYSEX]


### PR DESCRIPTION
Simplified mechanism for exposing resolution values from capabilities response. Intended to supersede #144

Signed-off-by: Rick Waldron <waldron.rick@gmail.com>