### PR TITLE
Deprecate Board.Board

### DIFF
--- a/examples/servo-config.js
+++ b/examples/servo-config.js
@@ -1,4 +1,4 @@
-var Board = require("../lib/firmata").Board;
+var Board = require("../lib/firmata");
 var board = new Board("/dev/tty.usbmodem1421");
 
 board.on("ready", function() {

--- a/repl.js
+++ b/repl.js
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
 
-var firmata = require('./lib/firmata.js'),
+var Board = require('./lib/firmata.js'),
     repl = require('repl');
 console.log('Enter USB Port and press enter:');
 process.stdin.resume();
 process.stdin.setEncoding('utf8');
 process.stdin.once('data', function(chunk) {
     var port = chunk.replace('\n', '');
-    var board = new firmata.Board(port, function() {
+    var board = new Board(port, function() {
         console.log('Successfully Connected to ' + port);
         repl.start('firmata>').context.board = board;
     });

--- a/test/unit/firmata.test.js
+++ b/test/unit/firmata.test.js
@@ -2,7 +2,7 @@ require("../common/bootstrap");
 
 // Test specific internals
 //
-var Board = firmata.Board;
+var Board = firmata;
 
 var ANALOG_MAPPING_QUERY = 0x69;
 var ANALOG_MAPPING_RESPONSE = 0x6A;


### PR DESCRIPTION
A proposal: Formally deprecate [the `Board.Board` property](https://github.com/islemaster/firmata.js/blob/master/lib/firmata.js#L2040-L2041) (a.k.a. `Firmata.Board`) by removing all internal uses and printing a deprecation warning if it's ever used.

`Board.Board` is an alias of the Firmata module's default export, and has been marked "Included for backwards compatibility" [since v0.4.1](https://github.com/firmata/firmata.js/commit/6c8458b0a430a725f708095cf7b39572d8ffff98).  It doesn't show up [in the usage documentation](https://github.com/firmata/firmata.js/blob/master/readme.md#usage) either, except for [one very old case in the servo-config.js example](https://github.com/islemaster/firmata.js/blame/master/examples/servo-config.js#L1).

Spying on or stubbing the `Firmata` constructor can still be achieved with a tool like [`proxyquire`](https://github.com/thlorenz/proxyquire) (and here's [an example](https://github.com/rwaldron/playground-io/pull/7) of that).