### PR TITLE
Updated jsdocs to make IDE work properly

### DIFF
--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -1148,13 +1148,13 @@ Board.prototype.sendI2CWriteRequest = function(slaveAddress, bytes) {
  * Write data to a register
  *
  * @param {number} address      The address of the I2C device.
- * @param {array} cmdRegOrData  An array of bytes
+ * @param {Array} cmdRegOrData  An array of bytes
  *
  * Write a command to a register
  *
  * @param {number} address      The address of the I2C device.
  * @param {number} cmdRegOrData The register
- * @param {array} inBytes       An array of bytes
+ * @param {Array} inBytes       An array of bytes
  *
  */
 
@@ -1819,7 +1819,7 @@ Board.prototype.serialConfig = function(options) {
 /**
  * Write an array of bytes to the specified serial port.
  * @param {number} portId The serial port to write to.
- * @param {array} inBytes An array of bytes to write to the serial port.
+ * @param {Array} inBytes An array of bytes to write to the serial port.
  */
 
 Board.prototype.serialWrite = function(portId, inBytes) {
@@ -1968,7 +1968,7 @@ Board.prototype.sysexResponse = function(commandByte, handler) {
 /**
  * Allow user code to send arbitrary sysex messages
  *
- * @param {array} message The message array is expected to be all necessary bytes
+ * @param {Array} message The message array is expected to be all necessary bytes
  *                        between START_SYSEX and END_SYSEX (non-inclusive). It will
  *                        be assumed that the data in the message array is
  *                        already encoded as 2 7-bit bytes LSB first.


### PR DESCRIPTION
When `{array}` is the type of parameter, some IDEs (WebStorm, for example) highlight valid function calls as parameter type mismatch.
It should be `{Array}`.