### PR TITLE
Add `Board.clearSysexResponse(commandByte)`.

### DIFF
--- a/lib/firmata.js
+++ b/lib/firmata.js
@@ -2327,6 +2327,19 @@ Board.prototype.sysexResponse = function(commandByte, handler) {
   return this;
 };
 
+/*
+ * Allow user to remove sysex response handlers.
+ *
+ * @param {number} commandByte The commandByte to disassociate with a handler
+ *                             previously set via `sysexResponse( commandByte, handler)`.
+ */
+
+Board.prototype.clearSysexResponse = function(commandByte) {
+  if (Board.SYSEX_RESPONSE[commandByte]) {
+    delete Board.SYSEX_RESPONSE[commandByte];
+  }
+};
+
 /**
  * Allow user code to send arbitrary sysex messages
  *

--- a/readme.md
+++ b/readme.md
@@ -580,6 +580,10 @@ accelStepper support 2, 3, and 4 wire configurations as well as step + direction
 
   - Use `Board.encode(data)` to encode data values into an array of 7-bit byte pairs.
 
+- `board.clearSysexResponse(commandByte)`
+
+  Allow user to remove sysex response handler such as one previously set through board.sysexResponse(commandByte, handler).
+
 
 ### Encode/Decode
 

--- a/test/unit/firmata.test.js
+++ b/test/unit/firmata.test.js
@@ -3638,6 +3638,17 @@ describe("Board: lifecycle", function() {
       done();
     });
 
+	it("allows clearing handler for SYSEX_RESPONSE command byte", function(done) {
+      Board.SYSEX_RESPONSE[0xFF] = function() {};
+
+      board.clearSysexResponse(0xFF);
+
+      assert.ok(function() {
+        board.sysexResponse(0xFF, function() {});
+      });
+      done();
+    });
+
   });
 
   describe("parser", function() {


### PR DESCRIPTION
This is useful for removing custom handlers when: something is disconnected from the larger system causing the custom handler to no longer be relevant, or when cleaning up between tests, removing any added handlers so they may be re-added in a successive test.