### PR TITLE
chore: Upgrade SerialPort

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "firmata-monorepo",
-  "version": "2.0.0",
+  "version": "2.0.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4723,7 +4723,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4744,12 +4745,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4764,17 +4767,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4891,7 +4897,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4903,6 +4910,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4917,6 +4925,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4924,12 +4933,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4948,6 +4959,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5028,7 +5040,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5040,6 +5053,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5125,7 +5139,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5161,6 +5176,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5180,6 +5196,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5223,12 +5240,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -8537,6 +8556,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -8861,7 +8881,8 @@
         "is-buffer": {
           "version": "1.1.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -8945,6 +8966,7 @@
           "version": "3.2.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -8991,7 +9013,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -9257,7 +9280,8 @@
         "repeat-string": {
           "version": "1.6.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "require-directory": {
           "version": "2.1.1",

--- a/packages/firmata-io/lib/firmata.js
+++ b/packages/firmata-io/lib/firmata.js
@@ -2427,7 +2427,7 @@ class Firmata extends Emitter {
   }
 
   /**
-   * Firmata.isAcceptablePort Determines if a `port` object (from SerialPort.list(...))
+   * Firmata.isAcceptablePort Determines if a `port` object (from SerialPort.list())
    * is a valid Arduino (or similar) device.
    * @return {Boolean} true if port can be connected to by Firmata
    */
@@ -2435,7 +2435,7 @@ class Firmata extends Emitter {
   static isAcceptablePort(port) {
     let rport = /usb|acm|^com/i;
 
-    if (rport.test(port.comName)) {
+    if (rport.test(port.path)) {
       return true;
     }
 
@@ -2452,22 +2452,18 @@ class Firmata extends Emitter {
       process.nextTick(() => {
         callback(new Error("No Transport provided"), null);
       });
-    } else {
-      Transport.list((error, ports) => {
-        const port = ports.find(port => Firmata.isAcceptablePort(port) && port);
-
-        /* istanbul ignore if */
-        if (error) {
-          callback(error, null);
-        } else {
-          if (port) {
-            callback(null, port);
-          } else {
-            callback(new Error("No Acceptable Port Found"), null);
-          }
-        }
-      });
+      return
     }
+    Transport.list().then((ports) => {
+      const port = ports.find(port => Firmata.isAcceptablePort(port) && port);
+      if (port) {
+        callback(null, port);
+      } else {
+        callback(new Error("No Acceptable Port Found"), null);
+      }
+    }).catch(error => {
+      callback(error, null);
+    });
   }
 
   // Expose encode/decode for custom sysex messages

--- a/packages/firmata-io/readme.md
+++ b/packages/firmata-io/readme.md
@@ -10,7 +10,7 @@ Install Firmata-io:
 npm install firmata-io --save
 ```
 
-Install a Transport: 
+Install a Transport:
 
 
 ```sh
@@ -30,11 +30,11 @@ Here's an example using the `Serialport` class:
 
 ```js
 // Require your Transport!
-const Serialport = require("serialport"); 
-// Pass the Transport class to the transport binding 
+const Serialport = require("serialport");
+// Pass the Transport class to the transport binding
 // function exported by firmata-io. The transport binding
 // function will return the Firmata class object with
-// the Transport class bound in its scope. 
+// the Transport class bound in its scope.
 const Firmata = require("firmata-io")(Serialport);
 
 Firmata.requestPort((error, port) => {
@@ -43,7 +43,7 @@ Firmata.requestPort((error, port) => {
     return;
   }
 
-  const board = new Firmata(port.comName);
+  const board = new Firmata(port.path);
 
   board.on("close", () => {
     // Unplug the board to see this event!
@@ -59,15 +59,15 @@ Here's an example using a `Serialport` instance:
 ```js
 // Require your Transport!
 const Serialport = require("serialport");
-// Get the Firmata class without a bound transport. 
+// Get the Firmata class without a bound transport.
 const Firmata = require("firmata-io").Firmata;
 
 Serialport.list().then(ports => {
   // Figure which port to use...
   const port = ports.find(port => port.manufacturer.startsWith("Arduino"));
-  
+
   // Instantiate an instance of your Transport class
-  const transport = new Serialport(port.comName);
+  const transport = new Serialport(port.path);
 
   // Pass the new instance directly to the Firmata class
   const board = new Firmata(transport);

--- a/packages/firmata.js/examples/adxl345.js
+++ b/packages/firmata.js/examples/adxl345.js
@@ -12,7 +12,7 @@ Board.requestPort((error, port) => {
     READ: 0xB2,
   };
 
-  const board = new Board(port.comName);
+  const board = new Board(port.path);
 
   board.on("ready", function() {
     console.log("Ready");

--- a/packages/firmata.js/examples/blink.js
+++ b/packages/firmata.js/examples/blink.js
@@ -6,7 +6,7 @@ Board.requestPort((error, port) => {
     return;
   }
 
-  const board = new Board(port.comName);
+  const board = new Board(port.path);
 
   board.on("ready", () => {
     const pin = 13;

--- a/packages/firmata.js/examples/close-events.js
+++ b/packages/firmata.js/examples/close-events.js
@@ -6,7 +6,7 @@ Board.requestPort((error, port) => {
     return;
   }
 
-  const board = new Board(port.comName);
+  const board = new Board(port.path);
 
   board.on("close", () => {
     // Unplug the board to see this event!

--- a/packages/firmata.js/examples/hw-serial-read-gps.js
+++ b/packages/firmata.js/examples/hw-serial-read-gps.js
@@ -6,7 +6,7 @@ Board.requestPort((error, port) => {
     return;
   }
 
-  const board = new Board(port.comName);
+  const board = new Board(port.path);
 
   board.on("ready", () => {
     console.log("READY");

--- a/packages/firmata.js/examples/johnny-five-io-plugin.js
+++ b/packages/firmata.js/examples/johnny-five-io-plugin.js
@@ -2,8 +2,8 @@ const SerialPort = require("serialport");
 const five = require("johnny-five");
 const Firmata = require("../");
 
-SerialPort.list((error, list) => {
-  const device = list.reduce((accum, item) => {
+SerialPort.list().then(ports => {
+  const device = ports.reduce((accum, item) => {
     if (item.manufacturer.indexOf("Arduino") === 0) {
       return item;
     }
@@ -17,7 +17,7 @@ SerialPort.list((error, list) => {
    */
 
   const board = new five.Board({
-    io: new Firmata(device.comName)
+    io: new Firmata(device.path)
   });
 
   board.on("ready", () => {

--- a/packages/firmata.js/examples/k22.js
+++ b/packages/firmata.js/examples/k22.js
@@ -10,7 +10,7 @@ Board.requestPort((error, port) => {
     console.log(error);
     return;
   }
-  const board = new Board(port.comName);
+  const board = new Board(port.path);
 
   board.on("ready", () => {
     const k22 = 0x68;

--- a/packages/firmata.js/examples/mma8452.js
+++ b/packages/firmata.js/examples/mma8452.js
@@ -12,7 +12,7 @@ Board.requestPort((error, port) => {
     READ_X_MSB: 0x01,
   };
 
-  const board = new Board(port.comName);
+  const board = new Board(port.path);
   // var board = new Board("/dev/cu.usbmodem1411");
 
   board.on("ready", function() {

--- a/packages/firmata.js/examples/reporting.js
+++ b/packages/firmata.js/examples/reporting.js
@@ -5,7 +5,7 @@ Board.requestPort((error, port) => {
     console.log(error);
     return;
   }
-  const board = new Board(port.comName);
+  const board = new Board(port.path);
 
   board.on("ready", function() {
     const a = 6;

--- a/packages/firmata.js/examples/servosweep.js
+++ b/packages/firmata.js/examples/servosweep.js
@@ -5,7 +5,7 @@ Board.requestPort((error, port) => {
     console.log(error);
     return;
   }
-  const board = new Board(port.comName);
+  const board = new Board(port.path);
 
   board.on("ready", () => {
     let degrees = 10;

--- a/packages/firmata.js/examples/stepper-accel.js
+++ b/packages/firmata.js/examples/stepper-accel.js
@@ -6,7 +6,7 @@ Board.requestPort((error, port) => {
     return;
   }
 
-  const board = new Board(port.comName);
+  const board = new Board(port.path);
 
   board.on("ready", () => {
 

--- a/packages/firmata.js/examples/stepper-driver.js
+++ b/packages/firmata.js/examples/stepper-driver.js
@@ -6,7 +6,7 @@ Board.requestPort((error, port) => {
     return;
   }
 
-  const board = new Board(port.comName);
+  const board = new Board(port.path);
 
   board.on("ready", () => {
 

--- a/packages/firmata.js/examples/stepper-multi.js
+++ b/packages/firmata.js/examples/stepper-multi.js
@@ -6,7 +6,7 @@ Board.requestPort((error, port) => {
     return;
   }
 
-  const board = new Board(port.comName);
+  const board = new Board(port.path);
 
   board.on("ready", () => {
 

--- a/packages/firmata.js/examples/stepper-three-wire.js
+++ b/packages/firmata.js/examples/stepper-three-wire.js
@@ -6,7 +6,7 @@ Board.requestPort(function(error, port) {
     return;
   }
 
-  var board = new Board(port.comName);
+  var board = new Board(port.path);
 
   board.on("ready", function() {
 

--- a/packages/firmata.js/examples/sw-serial-read-gps.js
+++ b/packages/firmata.js/examples/sw-serial-read-gps.js
@@ -5,7 +5,7 @@ Board.requestPort((error, port) => {
     console.log(error);
     return;
   }
-  const board = new Board(port.comName);
+  const board = new Board(port.path);
 
   board.on("ready", () => {
     console.log("READY");

--- a/packages/firmata.js/examples/test-analog-read.js
+++ b/packages/firmata.js/examples/test-analog-read.js
@@ -6,7 +6,7 @@ Board.requestPort((error, port) => {
     return;
   }
 
-  const board = new Board(port.comName);
+  const board = new Board(port.path);
 
   console.log(__filename);
   console.log("------------------------------");

--- a/packages/firmata.js/examples/test-i2c-read.js
+++ b/packages/firmata.js/examples/test-i2c-read.js
@@ -6,7 +6,7 @@ Board.requestPort((error, port) => {
     return;
   }
 
-  const board = new Board(port.comName);
+  const board = new Board(port.path);
 
   console.log(__filename);
   console.log("------------------------------");

--- a/packages/firmata.js/examples/test-serial-read.js
+++ b/packages/firmata.js/examples/test-serial-read.js
@@ -6,7 +6,7 @@ Board.requestPort((error, port) => {
     return;
   }
 
-  const board = new Board(port.comName);
+  const board = new Board(port.path);
 
   console.log(__filename);
   console.log("------------------------------");

--- a/packages/firmata.js/package-lock.json
+++ b/packages/firmata.js/package-lock.json
@@ -5,75 +5,75 @@
 	"requires": true,
 	"dependencies": {
 		"@serialport/binding-abstract": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@serialport/binding-abstract/-/binding-abstract-2.0.4.tgz",
-			"integrity": "sha512-0ZcSB6Gdxal55R/5McB0O359coXrO/GrmJlZ13cwN67gLsvmhmexCsd8b+H9CQ7dAbLih4HZSbfG9v8crrB0Gg==",
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@serialport/binding-abstract/-/binding-abstract-8.0.4.tgz",
+			"integrity": "sha512-1/CWzAk0tIlaf+WkTYD9YogUi6RGurNSV78cHlpkwsJeLY7z3i1rtwapspV5lIziGT/UJPj8pNVcXrv3K2uKZQ==",
 			"requires": {
-				"debug": "^4.1.0"
+				"debug": "^4.1.1"
 			}
 		},
 		"@serialport/binding-mock": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-2.0.4.tgz",
-			"integrity": "sha512-7c2dzVwwQIZKk+NFqC1mG0sTAwWR/GJY/4QbTn1Au3TnXhTj8nESYW/dURwsq6dGyl8+ZIPpKlRNu5Pr2tNxAQ==",
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-8.0.4.tgz",
+			"integrity": "sha512-n6XGkZQaEOZk+wvxKSCNwv9wopS3faD1nf97FJJwJXZdtKk7h2XFtScfrol3bBfHanDMLjwx8oLgs29Jtlxmwg==",
 			"requires": {
-				"@serialport/binding-abstract": "^2.0.4",
-				"debug": "^4.1.0"
+				"@serialport/binding-abstract": "^8.0.4",
+				"debug": "^4.1.1"
 			}
 		},
 		"@serialport/bindings": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@serialport/bindings/-/bindings-2.0.6.tgz",
-			"integrity": "sha512-MVdPLnWND8FaKByR+djw0rL6wyKuOYyZwBH87Ok+mo5rkObJRwF4fucfWuvSDjRgQFGX1SK5DWe9HxQ6BxSpWw==",
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@serialport/bindings/-/bindings-8.0.4.tgz",
+			"integrity": "sha512-VNEJs6swCw9D4X0M08850RFvj5wUt+YiVQrQ9/ms9sYfuh//S/TsEKKQuVkyYtaTkiyZUgknkzBH/8u74w8aKQ==",
 			"requires": {
-				"@serialport/binding-abstract": "^2.0.4",
-				"@serialport/parser-readline": "^2.0.2",
-				"bindings": "^1.3.0",
-				"debug": "^4.1.0",
-				"nan": "^2.12.1",
-				"prebuild-install": "^5.2.1"
+				"@serialport/binding-abstract": "^8.0.4",
+				"@serialport/parser-readline": "^8.0.4",
+				"bindings": "^1.5.0",
+				"debug": "^4.1.1",
+				"nan": "^2.14.0",
+				"prebuild-install": "^5.3.0"
 			}
 		},
 		"@serialport/parser-byte-length": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-2.0.2.tgz",
-			"integrity": "sha512-cUOprk1uRLucCJy6m+wAM4pwdBaB5D4ySi6juwRScP9DTjKUvGWYj5jzuqvftFBvYFmFza89aLj5K23xiiqj7Q=="
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-8.0.4.tgz",
+			"integrity": "sha512-5tQQbJZ5KL0eaP750oF1w0iT+E3lFkpDRz/BzONS2jJsGc+Warb+6FH2aWqj1+smz0mAZWdcxNQgJZLrhFy+sw=="
 		},
 		"@serialport/parser-cctalk": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-2.0.2.tgz",
-			"integrity": "sha512-5LMysRv7De+TeeoKzi4+sgouD4tqZEAn1agAVevw+7ILM0m30i1zgZLtchgxtCH7OoQRAkENEVEPc0OwhghKgw=="
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-8.0.4.tgz",
+			"integrity": "sha512-7GsVAlVgk9pAMfuhbEy5m5t1pe8WCdR8HzXjroE8jwXCPHrGT7aY/sjZSTF91fx+qzqhojLiTJyIlf1HwnqM+g=="
 		},
 		"@serialport/parser-delimiter": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-2.0.2.tgz",
-			"integrity": "sha512-zB02LahFfyZmJqak9l37vP/F1K+KCUxd1KQj35OhD1+0q/unMjVTZmsfkxFSM4gkaxP9j7+8USk+LQJ3V8U26Q=="
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-8.0.4.tgz",
+			"integrity": "sha512-4XkOQD2uj7jj4q4CltAM74Rk3HNwCk8pqrgvfAtouA3Pmt0AdrC/n9OrpRY13ioZwv+Yjc54HWU2z9VOOGn45Q=="
 		},
 		"@serialport/parser-readline": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-2.0.2.tgz",
-			"integrity": "sha512-thL26dGEHB+eINNydJmzcLLhiqcBQkF+wNTbRaYblTP/6dm7JsfjYSud7bTkN63AgE0xpe9tKXBFqc8zgJ1VKg==",
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-8.0.4.tgz",
+			"integrity": "sha512-STs0WnGKLBwlXbG3CnTiI+kuWxmHBzwcslrWA2su9G5pPYQJpKGCHs2URLDDhYKmGZtzTftCJXEXABpsTXfNxQ==",
 			"requires": {
-				"@serialport/parser-delimiter": "^2.0.2"
+				"@serialport/parser-delimiter": "^8.0.4"
 			}
 		},
 		"@serialport/parser-ready": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-2.0.2.tgz",
-			"integrity": "sha512-6ynQ+HIIkFQcEO2Hrq4Qmdz+hlJ7kjTHGQ1E7SRN7f70nnys1v3HSke8mjK3RzVw+SwL0rBYjftUdCTrU+7c+Q=="
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-8.0.4.tgz",
+			"integrity": "sha512-HXFmYve6mcFnOyX/efLvo7MpvOtD0uJrYWXFvuk0xw3DYRBvabL1zYvK0rYPrWJu32I0M3AFFsldSELm0Ic3mQ=="
 		},
 		"@serialport/parser-regex": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-2.0.2.tgz",
-			"integrity": "sha512-7qjYd7AdHUK8fJOmHpXlMRipqRCVMMyDFyf/5TQQiOt6q+BiFjLOtSpVXhakHwgnXanzDYKeRSB8zM0pZZg+LA=="
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-8.0.4.tgz",
+			"integrity": "sha512-uruaOaxBN4E90oqW/Tfb594uP9qPEgL79XXwXUQGbT554EK4k1VVa9TV1JO16qE8EB6Km6XxdEPEVxAx7HKmpg=="
 		},
 		"@serialport/stream": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-2.0.4.tgz",
-			"integrity": "sha512-x1OzTGGTA/ioE/wx7sM11KVxkZr5MqZNVTQXezl6wySCl5BkQTj1nc37e99p6aRQjMxAoY8BfIDJKXWwT5LSsA==",
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-8.0.4.tgz",
+			"integrity": "sha512-Ux6qhFRPGiW/2XYpR6PeZSCidF32eqC5GEpXrjwHGmif0wvuGWjbJVfl1azBvgXcjARWeyGjSwVEcsJbsDX1QQ==",
 			"requires": {
-				"@serialport/binding-mock": "^2.0.4",
-				"debug": "^4.1.0"
+				"@serialport/binding-mock": "^8.0.4",
+				"debug": "^4.1.1"
 			}
 		},
 		"ansi-regex": {
@@ -96,42 +96,37 @@
 			}
 		},
 		"bindings": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
-			"integrity": "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew=="
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"requires": {
+				"file-uri-to-path": "1.0.0"
+			}
 		},
 		"bl": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-			"integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
+			"integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
 			"requires": {
-				"readable-stream": "^2.3.5",
-				"safe-buffer": "^5.1.1"
+				"readable-stream": "^3.0.1"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
-		},
-		"buffer-alloc": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-			"integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-			"requires": {
-				"buffer-alloc-unsafe": "^1.1.0",
-				"buffer-fill": "^1.0.0"
-			}
-		},
-		"buffer-alloc-unsafe": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-			"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
-		},
-		"buffer-fill": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-			"integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
 		},
 		"chownr": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-			"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
+			"integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw=="
 		},
 		"code-point-at": {
 			"version": "1.1.0",
@@ -157,11 +152,11 @@
 			}
 		},
 		"decompress-response": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+			"integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
 			"requires": {
-				"mimic-response": "^1.0.0"
+				"mimic-response": "^2.0.0"
 			}
 		},
 		"deep-extend": {
@@ -180,9 +175,9 @@
 			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
 		},
 		"end-of-stream": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
 			"requires": {
 				"once": "^1.4.0"
 			}
@@ -191,6 +186,11 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
 			"integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
+		},
+		"file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
 		},
 		"fs-constants": {
 			"version": "1.0.0",
@@ -223,9 +223,9 @@
 			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
 		},
 		"inherits": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"ini": {
 			"version": "1.3.5",
@@ -246,9 +246,9 @@
 			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
 		"mimic-response": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.0.0.tgz",
+			"integrity": "sha512-8ilDoEapqA4uQ3TwS0jakGONKXVJqpy+RpM+3b7pLdOjghCrEiGp9SRkFbUHAmZW9vdnrENWHjaweIoTIJExSQ=="
 		},
 		"minimist": {
 			"version": "1.2.0",
@@ -271,14 +271,14 @@
 			}
 		},
 		"ms": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"nan": {
-			"version": "2.12.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
-			"integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+			"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
 		},
 		"napi-build-utils": {
 			"version": "1.0.1",
@@ -286,9 +286,9 @@
 			"integrity": "sha512-boQj1WFgQH3v4clhu3mTNfP+vOBxorDlE8EKiMjUlLG3C4qAESnn9AxIOkFgTR2c9LtzNjPrjS60cT27ZKBhaA=="
 		},
 		"node-abi": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.5.1.tgz",
-			"integrity": "sha512-oDbFc7vCFx0RWWCweTer3hFm1u+e60N5FtGnmRV6QqvgATGFH/XRR6vqWIeBVosCYCqt6YdIr2L0exLZuEdVcQ==",
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.13.0.tgz",
+			"integrity": "sha512-9HrZGFVTR5SOu3PZAnAY2hLO36aW1wmA+FDsVkr85BTST32TLCA1H/AEcatVRAsWLyXS3bqUDYCAjq5/QGuSTA==",
 			"requires": {
 				"semver": "^5.4.1"
 			}
@@ -327,15 +327,10 @@
 				"wrappy": "1"
 			}
 		},
-		"os-homedir": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-		},
 		"prebuild-install": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.2.2.tgz",
-			"integrity": "sha512-4e8VJnP3zJdZv/uP0eNWmr2r9urp4NECw7Mt1OSAi3rcLrbBRxGiAkfUFtre2MhQ5wfREAjRV+K1gubvs/GPsA==",
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.3.tgz",
+			"integrity": "sha512-GV+nsUXuPW2p8Zy7SarF/2W/oiK8bFQgJcncoJ0d7kRpekEA0ftChjfEaF9/Y+QJEc/wFR7RAEa8lYByuUIe2g==",
 			"requires": {
 				"detect-libc": "^1.0.3",
 				"expand-template": "^2.0.3",
@@ -343,27 +338,26 @@
 				"minimist": "^1.2.0",
 				"mkdirp": "^0.5.1",
 				"napi-build-utils": "^1.0.1",
-				"node-abi": "^2.2.0",
+				"node-abi": "^2.7.0",
 				"noop-logger": "^0.1.1",
 				"npmlog": "^4.0.1",
-				"os-homedir": "^1.0.1",
-				"pump": "^2.0.1",
+				"pump": "^3.0.0",
 				"rc": "^1.2.7",
-				"simple-get": "^2.7.0",
-				"tar-fs": "^1.13.0",
+				"simple-get": "^3.0.3",
+				"tar-fs": "^2.0.0",
 				"tunnel-agent": "^0.6.0",
 				"which-pm-runs": "^1.0.0"
 			}
 		},
 		"process-nextick-args": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
 		},
 		"pump": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
@@ -400,25 +394,25 @@
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"semver": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-			"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 		},
 		"serialport": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/serialport/-/serialport-7.1.3.tgz",
-			"integrity": "sha512-gT4db1SqrGCxW43lLpENO3WJJwhGK9DlP1ilKDHwYtHqfWssgzoDyI8n+KQHFVxMx51PPU3A5mMgwPRrA7IHCQ==",
+			"version": "8.0.5",
+			"resolved": "https://registry.npmjs.org/serialport/-/serialport-8.0.5.tgz",
+			"integrity": "sha512-hYWRpn+pRZWxwCZErLkYcja/ELSrB70dl+z9TcKIHKO2SlHDVNJmXAGGw2nfjg3AqmsHZvRRq8fu1SySYzbZUA==",
 			"requires": {
-				"@serialport/binding-mock": "^2.0.4",
-				"@serialport/bindings": "^2.0.6",
-				"@serialport/parser-byte-length": "^2.0.2",
-				"@serialport/parser-cctalk": "^2.0.2",
-				"@serialport/parser-delimiter": "^2.0.2",
-				"@serialport/parser-readline": "^2.0.2",
-				"@serialport/parser-ready": "^2.0.2",
-				"@serialport/parser-regex": "^2.0.2",
-				"@serialport/stream": "^2.0.4",
-				"debug": "^4.1.0"
+				"@serialport/binding-mock": "^8.0.4",
+				"@serialport/bindings": "^8.0.4",
+				"@serialport/parser-byte-length": "^8.0.4",
+				"@serialport/parser-cctalk": "^8.0.4",
+				"@serialport/parser-delimiter": "^8.0.4",
+				"@serialport/parser-readline": "^8.0.4",
+				"@serialport/parser-ready": "^8.0.4",
+				"@serialport/parser-regex": "^8.0.4",
+				"@serialport/stream": "^8.0.4",
+				"debug": "^4.1.1"
 			}
 		},
 		"set-blocking": {
@@ -437,11 +431,11 @@
 			"integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
 		},
 		"simple-get": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
-			"integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
+			"integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
 			"requires": {
-				"decompress-response": "^3.3.0",
+				"decompress-response": "^4.2.0",
 				"once": "^1.3.1",
 				"simple-concat": "^1.0.0"
 			}
@@ -478,45 +472,39 @@
 			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
 		},
 		"tar-fs": {
-			"version": "1.16.3",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
-			"integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.0.tgz",
+			"integrity": "sha512-vaY0obB6Om/fso8a8vakQBzwholQ7v5+uy+tF3Ozvxv1KNezmVQAiWtcNmMHFSFPqL3dJA8ha6gdtFbfX9mcxA==",
 			"requires": {
-				"chownr": "^1.0.1",
+				"chownr": "^1.1.1",
 				"mkdirp": "^0.5.1",
-				"pump": "^1.0.0",
-				"tar-stream": "^1.1.2"
-			},
-			"dependencies": {
-				"pump": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-					"integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
-					"requires": {
-						"end-of-stream": "^1.1.0",
-						"once": "^1.3.1"
-					}
-				}
+				"pump": "^3.0.0",
+				"tar-stream": "^2.0.0"
 			}
 		},
 		"tar-stream": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
-			"integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.0.tgz",
+			"integrity": "sha512-+DAn4Nb4+gz6WZigRzKEZl1QuJVOLtAwwF+WUxy1fJ6X63CaGaUAxJRD2KEn1OMfcbCjySTYpNC6WmfQoIEOdw==",
 			"requires": {
-				"bl": "^1.0.0",
-				"buffer-alloc": "^1.2.0",
-				"end-of-stream": "^1.0.0",
+				"bl": "^3.0.0",
+				"end-of-stream": "^1.4.1",
 				"fs-constants": "^1.0.0",
-				"readable-stream": "^2.3.0",
-				"to-buffer": "^1.1.1",
-				"xtend": "^4.0.0"
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
-		},
-		"to-buffer": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-			"integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
@@ -548,11 +536,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-		},
-		"xtend": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
 		}
 	}
 }

--- a/packages/firmata.js/package.json
+++ b/packages/firmata.js/package.json
@@ -12,7 +12,7 @@
   "main": "./lib/firmata",
   "dependencies": {
     "firmata-io": "^2.0.0",
-    "serialport": "^7.1.3"
+    "serialport": "^8.0.5"
   },
   "scripts": {
     "test": "grunt",

--- a/packages/firmata.js/readme.md
+++ b/packages/firmata.js/readme.md
@@ -32,7 +32,7 @@ If you run *firmata* from the command line it will prompt you for the serial por
 
 ### Using the `"ready"` event...
 
-#### With a path string: 
+#### With a path string:
 
 ```js
 const Firmata = require("firmata");
@@ -105,40 +105,40 @@ const board = new Firmata(new Etherport(...), () => {
 
 # `Firmata`
 
-The `Firmata` constructor creates an instance that represents a physical board. 
+The `Firmata` constructor creates an instance that represents a physical board.
 
-- `new Firmata(path[, options][, readyCallback])` 
-- `new Firmata(port[, options][, readyCallback])` 
+- `new Firmata(path[, options][, readyCallback])`
+- `new Firmata(port[, options][, readyCallback])`
 
   | Parameter | Type   | Description | Default  | Required |
   |-----------|------- |------------ |--------- |----------|
-  | path      | String | A system path or port name. | none | Yes\* | 
-  | port      | Transport | A Transport object. | none | Yes\* | 
-  | [options] | object | Optional settings to used when constructing. | [See Below](#board-options) | No | 
-  | [readyCallback] | function | Optional "ready" callback to call when connection to board is complete. | none | No | 
+  | path      | String | A system path or port name. | none | Yes\* |
+  | port      | Transport | A Transport object. | none | Yes\* |
+  | [options] | object | Optional settings to used when constructing. | [See Below](#board-options) | No |
+  | [readyCallback] | function | Optional "ready" callback to call when connection to board is complete. | none | No |
 
   \* _**Either**_ a **path** or a **port** are required.
 
-  - Notes: 
-    - `new Firmata(path: string)`: instances can be constructed using only a system path of the serial port to open or name, for example: 
+  - Notes:
+    - `new Firmata(path: string)`: instances can be constructed using only a system path of the serial port to open or name, for example:
       + `new Firmata("/dev/usb.whatever")`
       + `new Firmata("/dev/ttyACM0")`
       + `new Firmata("COM1")`
-    - `new Firmata(port: Transport)`: instances can be constructed using a "Transport" object, for example: 
-      + `new Firmata(new Serialport(...))` 
+    - `new Firmata(port: Transport)`: instances can be constructed using a "Transport" object, for example:
+      + `new Firmata(new Serialport(...))`
       + `new Firmata(new Etherport(...))`
 
 - Options<a name="board-options"></a>
 
   | Property | Type   | Description | Default  | Required |
   |-----------|------- |------------ |--------- |----------|
-  | skipCapabilities | Boolean | Set to `true` to skip the `CAPABILITY_QUERY` | `true` | No | 
-  | reportVersionTimeout | Number | Time in milliseconds to wait before timing out the initial request for the firmware version. | 5000 | No | 
-  | samplingInterval | Number | Time in milliseconds of the sampling interval on the actual board. | 19 | No | 
-  | serialport | Object | See: [Serialport:openOptions](https://github.com/EmergingTechnologyAdvisors/node-serialport#module_serialport--SerialPort..openOptions). These will be ignored if the first argument is a Transport object. | \* | No | 
+  | skipCapabilities | Boolean | Set to `true` to skip the `CAPABILITY_QUERY` | `true` | No |
+  | reportVersionTimeout | Number | Time in milliseconds to wait before timing out the initial request for the firmware version. | 5000 | No |
+  | samplingInterval | Number | Time in milliseconds of the sampling interval on the actual board. | 19 | No |
+  | serialport | Object | See: [Serialport:openOptions](https://github.com/EmergingTechnologyAdvisors/node-serialport#module_serialport--SerialPort..openOptions). These will be ignored if the first argument is a Transport object. | \* | No |
 
   \* Defaults are defined in `Serialport`.
-  
+
 
 
 
@@ -463,10 +463,10 @@ accelStepper support 2, 3, and 4 wire configurations as well as step + direction
   }
   ```
 
-- `board.STEPPER.STEP_SIZE` 
+- `board.STEPPER.STEP_SIZE`
 
   Available step sizes.
-  
+
   ```js
   {
     WHOLE: 0,
@@ -474,17 +474,17 @@ accelStepper support 2, 3, and 4 wire configurations as well as step + direction
   }
   ```
 
-- `board.STEPPER.DIRECTION` 
+- `board.STEPPER.DIRECTION`
 
   Stepper directions.
-  
+
   ```js
   {
     CCW: 0,
     CW: 1
   }
   ```
-  
+
   - `board.accelStepperConfig(options)`
 
   Configure a stepper motor
@@ -504,11 +504,11 @@ accelStepper support 2, 3, and 4 wire configurations as well as step + direction
       invertPins: 0 // <number> (optional) Controls which pins to invert (see table below); default is 0
     }
     ```
-    
+
     **invertPins**
 
     The invertPins value is a 5-bit number
-    
+
     bit 5           |bit 4           |bit 3           |bit 2           |bit 1
     ----------------|----------------|----------------|----------------|----------------
     invert motorPin1|invert motorPin2|invert motorPin3|invert motorPin4|invert enablePin
@@ -553,7 +553,7 @@ accelStepper support 2, 3, and 4 wire configurations as well as step + direction
   Set the acceleration and deceleration for the stepper in steps / sec^2
 
 - `board.multiStepperConfig(opts)`
-  
+
   Configure a multStepper group. multiStepper groups allow you to pass an array of targeted positions and have all the steppers move to their targets and arrive at the same time. Note that acceleration cannot be used when moving a multiStepper group.
 
   ```

--- a/packages/firmata.js/test/unit/com.test.js
+++ b/packages/firmata.js/test/unit/com.test.js
@@ -9,7 +9,7 @@ describe("com.*", () => {
   const response = {
     error: null,
     port: {
-      comName: null
+      path: null
     },
   };
 

--- a/packages/firmata.js/test/unit/firmata.test.js
+++ b/packages/firmata.js/test/unit/firmata.test.js
@@ -67,49 +67,47 @@ describe("Board.requestPort", () => {
   const response = {
     error: null,
     port: {
-      comName: null
+      path: null
     },
   };
 
   beforeEach(() => {
-    sandbox.stub(com, "list").callsFake(callback => {
-      process.nextTick(() => {
-        callback(response.error, [response.port]);
-      });
+    sandbox.stub(com, "list").callsFake(() => {
+      return response.error ? Promise.reject(error) : Promise.resolve([response.port])
     });
   });
 
   afterEach(() => {
     sandbox.restore();
     response.error = null;
-    response.port.comName = null;
+    response.port.path = null;
   });
 
   it("can identify an acceptable port", done => {
-    response.port.comName = "/dev/usb.whatever";
+    response.port.path = "/dev/usb.whatever";
     assert.equal(Board.isAcceptablePort(response.port), true);
 
-    response.port.comName = "/dev/ttyACM0";
+    response.port.path = "/dev/ttyACM0";
     assert.equal(Board.isAcceptablePort(response.port), true);
 
-    response.port.comName = "COM0";
+    response.port.path = "COM0";
     assert.equal(Board.isAcceptablePort(response.port), true);
 
     done();
   });
 
   it("can identify an unacceptable port", done => {
-    response.port.comName = "/dev/tty.Bluetooth-Incoming-Port";
+    response.port.path = "/dev/tty.Bluetooth-Incoming-Port";
     assert.equal(Board.isAcceptablePort(response.port), false);
 
-    response.port.comName = "/dev/someotherthing";
+    response.port.path = "/dev/someotherthing";
     assert.equal(Board.isAcceptablePort(response.port), false);
 
     done();
   });
 
   it("invokes callback with an acceptable port: usb", done => {
-    response.port.comName = "/dev/usb.whatever";
+    response.port.path = "/dev/usb.whatever";
 
     Board.requestPort((error, port) => {
       assert.equal(port, response.port);
@@ -118,7 +116,7 @@ describe("Board.requestPort", () => {
   });
 
   it("invokes callback with an acceptable port: acm", done => {
-    response.port.comName = "/dev/ttyACM0";
+    response.port.path = "/dev/ttyACM0";
 
     Board.requestPort((error, port) => {
       assert.equal(port, response.port);
@@ -127,7 +125,7 @@ describe("Board.requestPort", () => {
   });
 
   it("invokes callback with an acceptable port: com", done => {
-    response.port.comName = "COM0";
+    response.port.path = "COM0";
 
     Board.requestPort((error, port) => {
       assert.equal(port, response.port);
@@ -136,7 +134,7 @@ describe("Board.requestPort", () => {
   });
 
   it("doesn't call callback with an unacceptable port: Bluetooth-Incoming-Port", done => {
-    response.port.comName = "/dev/tty.Bluetooth-Incoming-Port";
+    response.port.path = "/dev/tty.Bluetooth-Incoming-Port";
 
     Board.requestPort((error, port) => {
       assert.equal(port, null);


### PR DESCRIPTION
SerialPort v8 brings support for the latest versions of node and electron. The api has had two major breaking changes. `.list()` no longer takes a callback and only returns a promise. And the `PortInfo` object now has `path` instead of `comName`.

This would probably be a breaking change for Firmata as well.

I haven't tested this PR on hardware yet.