### PR TITLE
Return an error when no firmata is detected

### DIFF
--- a/packages/firmata-io/lib/firmata.js
+++ b/packages/firmata-io/lib/firmata.js
@@ -725,6 +725,9 @@ class Firmata extends Emitter {
       if (this.versionReceived === false) {
         this.reportVersion(function() {});
         this.queryFirmware(function() {});
+        this.NoFirmataPresent = setTimeout( () => {
+          callback(true);
+        },settings.reportVersionTimeout);
       }
     }, settings.reportVersionTimeout);
 
@@ -740,6 +743,7 @@ class Firmata extends Emitter {
     // Await the reported version.
     this.once("reportversion", () => {
       clearTimeout(this.reportVersionTimeoutId);
+      clearTimeout(this.NoFirmataPresent);
       this.versionReceived = true;
       this.once("queryfirmware", () => {
 


### PR DESCRIPTION
What ?
fire an second timer when no version has been received since "reportVersionTimeout". In the end, raise an error by calling the callback function with "true" as argument.

Why ?
In some case, it would be interesting to notice a discovery failure. In that way, the application could alert user that firmata is not running in the device.
