### PR TITLE
Improved support for Chrome Apps and NW.js

### DIFF
--- a/packages/firmata.js/lib/com.js
+++ b/packages/firmata.js/lib/com.js
@@ -40,6 +40,9 @@ try {
   /* istanbul ignore else */
   if (process.env.IS_TEST_MODE) {
     com = TransportStub;
+  } else if (process && process.versions.nw && parseFloat(process.versions.nw) >= 0.13) {
+    SerialPort = require("nwjs-serialport").SerialPort;
+    com = SerialPort;
   } else {
     SerialPort = require("serialport");
     com = SerialPort;

--- a/packages/firmata.js/lib/com.js
+++ b/packages/firmata.js/lib/com.js
@@ -40,8 +40,8 @@ try {
   /* istanbul ignore else */
   if (process.env.IS_TEST_MODE) {
     com = TransportStub;
-  } else if (process && process.versions.nw && parseFloat(process.versions.nw) >= 0.13) {
-    SerialPort = require("nwjs-serialport").SerialPort;
+  } else if (chrome && chrome.serial) {
+    SerialPort = require("chrome-apps-serialport").SerialPort;
     com = SerialPort;
   } else {
     SerialPort = require("serialport");

--- a/packages/firmata.js/package.json
+++ b/packages/firmata.js/package.json
@@ -14,6 +14,9 @@
     "firmata-io": "^2.2.0",
     "serialport": "^8.0.5"
   },
+  "optionalDependencies": {
+    "nwjs-serialport": "^1.0.0"
+  },
   "scripts": {
     "test": "grunt",
     "test-cover": "nyc grunt test",

--- a/packages/firmata.js/package.json
+++ b/packages/firmata.js/package.json
@@ -12,10 +12,8 @@
   "main": "./lib/firmata",
   "dependencies": {
     "firmata-io": "^2.2.0",
-    "serialport": "^8.0.5"
-  },
-  "optionalDependencies": {
-    "nwjs-serialport": "^1.0.0"
+    "serialport": "^8.0.5",
+    "chrome-apps-serialport": "^1.0.0"
   },
   "scripts": {
     "test": "grunt",

--- a/packages/firmata.js/package.json
+++ b/packages/firmata.js/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "firmata-io": "^2.2.0",
     "serialport": "^8.0.5",
-    "chrome-apps-serialport": "^1.0.0"
+    "chrome-apps-serialport": "^1.0.4"
   },
   "scripts": {
     "test": "grunt",

--- a/packages/firmata.js/package.json
+++ b/packages/firmata.js/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "firmata-io": "^2.2.0",
     "serialport": "^8.0.5",
-    "chrome-apps-serialport": "^1.0.4"
+    "chrome-apps-serialport": "^1.0.5"
   },
   "scripts": {
     "test": "grunt",


### PR DESCRIPTION
This PR conditionally requires the new `chrome-apps-serialport` module when `firmata.js` is used inside a Chrome App (including NW.js). This module replaces `browser-serialport` which has not been updated in years. The new module's API is aligned with that of `node-serialport` v8.x+.

By merging this PR, you allow users of Firmata the ability to run their code inside NW.js without being forced to recompile the native `node-serialport` module, an operation which can prove to be quite complicated.