### PR TITLE
Fixing unplug detection in firmata.js

### DIFF
--- a/packages/firmata-io/lib/firmata.js
+++ b/packages/firmata-io/lib/firmata.js
@@ -594,7 +594,7 @@ class Firmata extends Emitter {
     this.transport.on("close", event => {
 
       // https://github.com/node-serialport/node-serialport/blob/5.0.0/UPGRADE_GUIDE.md#opening-and-closing
-      if (event && event.disconnect && event.disconnected) {
+      if (event && event.disconnected) {
         this.emit("disconnect");
         return;
       }


### PR DESCRIPTION
I'm removing the check for event.disconnect as it never returns true from the serialport library. Only checking for the valid responses of event && event.disconnected allows the unplug detection to work in the latest serialport version.
referencing the issue - https://github.com/firmata/firmata.js/issues/234