### PR TITLE
Fixing MODES.ANALOG case in pinMode function

### DIFF
--- a/packages/firmata-io/lib/firmata.js
+++ b/packages/firmata-io/lib/firmata.js
@@ -934,23 +934,14 @@ class Firmata extends Emitter {
 
   pinMode(pin, mode) {
     if (mode === this.MODES.ANALOG) {
-      // Because pinMode may be called before analogRead(pin, () => {}), but isn't
-      // necessary to initiate an analog read on an analog pin, we'll assign the
-      // mode here, but do nothing further. In analogRead(), the call to
-      // reportAnalogPin(pin, 1) is all that's needed to turn on analog input
-      // reading.
-      //
-      // reportAnalogPin(...) will reconcile the pin number as well, the
-      // same operation we use here to assign a "mode":
-      this.pins[this.analogPins[pin]].mode = mode;
-    } else {
+      pin = this.analogPins[pin];
+    }
       this.pins[pin].mode = mode;
       writeToTransport(this, [
         PIN_MODE,
         pin,
         mode
       ]);
-    }
   }
 
   /**


### PR DESCRIPTION
As it's is written, it isn't necessary to initiate an analog read on an analog pin at the beginning, so current code is ok for a first operation.
But if I change this pinMode and after this, I turn again to "ANALOG", the reporting is not updating its value because we need to inform the board.

I keep the pin "recalculation" to keep compatibility with current firmata.js version.

Thanks
Joan